### PR TITLE
(#3) add routes into HTTP_Server struct to improve API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,7 @@ To run the tests, go to the `build` folder and use  `make test CTEST_OUTPUT_ON_F
 ### Development
 After running `make` inside your build folder, a `main` executable will be generated inside `build/src` and copy over the `templates/` and `static/` folders. Use `./src/main` (assuming you're inside the `build` folder) to run the server. By default it's on port `6969` then go to `localhost:6969` in your browser. This is the development/testing server that you can play around with.
 
+When killing the server (e.g., Ctrl+C) you may need to wait ~10 seconds and/or kill the server a few times for it to pick up a connection again (at least, this has been my experience...)
+
 ### Building a webserver
 Will write more detail once library is more mature.

--- a/include/HTTP_Server.h
+++ b/include/HTTP_Server.h
@@ -10,7 +10,6 @@
 
 // forward declaration
 struct SortedArray;
-struct Route;
 
 // note: please keep these in the same order as _status_code_text
 // as that's the corresponding lookup table
@@ -67,5 +66,21 @@ void http_set_response_body(
 		HTTP_Server* const http_server,
 		const char* body);
 
+// Add a route that renders a template
+// (always a GET request)
+void http_add_route_template(
+		HTTP_Server* const http_server,
+		char* route_path,
+		char* template_file_name);
+
+// Add a route that handles a custom callback
+// Supports GET and/or POST.
+// One route can have multiple request types at once (GET/POST).
+void http_add_route_api(
+		HTTP_Server* const http_server,
+		char* route_path,
+		void* user_data,
+		char* (*get_callback)(struct SortedArray*, void*),
+		void (*post_callback)(struct SortedArray*, void*, char*));
 
 #endif

--- a/include/Routes.h
+++ b/include/Routes.h
@@ -13,10 +13,10 @@ struct Route {
 	void* user_data;
 
 	char* (*get_callback)(
-			struct SortedArray * sarray, 
+			struct SortedArray * params, 
 			void* user_data);
 	void (*post_callback)(
-			struct SortedArray * sarray,
+			struct SortedArray * params,
 			void* user_data,
 			char* request_body);
 
@@ -38,8 +38,10 @@ void addRoute(
 		char* (*get_callback)(struct SortedArray*, void*),
 		void (*post_callback)(struct SortedArray*, void*, char*));
 
-struct Route * search(struct Route * root, char * key);
+struct Route * search(
+		struct Route * root, 
+		char * key);
 
-void inorder(struct Route * root );
+void inorder(const struct Route * const root );
 
 #endif

--- a/src/HTTP_Server.c
+++ b/src/HTTP_Server.c
@@ -324,3 +324,32 @@ void http_set_response_body(
 		strncat(http_server->response_body, response_body, max_len);
 	}
 }
+
+void http_add_route_template(
+		HTTP_Server* const http_server,
+		char* route_path,
+		char* template_file_name)
+{
+	if (!http_server->routes)
+		http_server->routes = initRoute(route_path, template_file_name, NULL, NULL, NULL);
+	else
+		addRoute(&http_server->routes, route_path, template_file_name, NULL, NULL, NULL);
+}
+
+void http_add_route_api(
+		HTTP_Server* const http_server,
+		char* route_path,
+		void* user_data,
+		char* (*get_callback)(
+			struct SortedArray* params, 
+			void* user_data),
+		void (*post_callback)(
+			struct SortedArray* params, 
+			void* user_data, 
+			char* request_body))
+{
+	if (!http_server->routes)
+		http_server->routes = initRoute(route_path, NULL, user_data, get_callback, post_callback);
+	else
+		addRoute(&http_server->routes, route_path, NULL, user_data, get_callback, post_callback);
+}

--- a/src/Routes.c
+++ b/src/Routes.c
@@ -12,7 +12,7 @@ struct Route * initRoute(
 {
 	struct Route * temp = (struct Route *) malloc(sizeof(struct Route));
 
-	temp->key = key;
+	temp->key =  key;
 	temp->value = value;
 	temp->get_callback = get_callback;
 	temp->post_callback = post_callback;
@@ -22,7 +22,7 @@ struct Route * initRoute(
 	return temp;
 }
 
-void inorder(struct Route* root)
+void inorder(const struct Route* const root)
 {
 
     if (root != NULL) {
@@ -52,7 +52,9 @@ void addRoute(
 	}
 }
 
-struct Route * search(struct Route * root, char* key) {
+struct Route * search(
+		struct Route * root,
+		char* key) {
 	if (root == NULL) {
 		return NULL;
 	} 

--- a/src/main.c
+++ b/src/main.c
@@ -40,17 +40,16 @@ int main() {
 	http_init(&http_server, 6969);
 
 	// registering Routes
-	// TODO: move adding routes into HTTP server (e.g., http_add_route())
-	// TODO: split these into addTemplateRoute and addApiRoute since
 	// a template route will never have get/post callbacks (they only return HTML).
-	http_server.routes = initRoute("/", "index.html", NULL, NULL, NULL); 
-	addRoute(&http_server.routes, "/about", "about.html", NULL, NULL, NULL);
-	addRoute(&http_server.routes, "/sth", "sth.html", NULL, NULL, NULL);
-	addRoute(&http_server.routes, "/chicken", "chicken.html", NULL, NULL, NULL);
+	// by default these will search the templates/ folder
+	http_add_route_template(&http_server, "/", "index.html");
+	http_add_route_template(&http_server, "/about", "about.html");
+	http_add_route_template(&http_server, "/sth", "sth.html");
+	http_add_route_template(&http_server, "/chicken", "chicken.html");
 
 	// TODO: might need to pass deallocators as well to free user data
 	char* my_str = strdup("hello there!");
-	addRoute(&http_server.routes, "/mystr", NULL, &my_str, &get_str, &set_str);
+	http_add_route_api(&http_server, "/mystr", &my_str, &get_str, &set_str);
 
 	printf("\n====================================\n");
 	printf("=========ALL AVAILABLE ROUTES========\n");


### PR DESCRIPTION
Moved routes natively into the HTTP server struct that way it's not handled externally. This also has the side benefit of cleaning up the API a bit when adding template routes vs API routes