### PR TITLE
(#4) add deallocators for user data and server memory cleanup

### DIFF
--- a/include/HTTP_Server.h
+++ b/include/HTTP_Server.h
@@ -80,7 +80,11 @@ void http_add_route_api(
 		HTTP_Server* const http_server,
 		char* route_path,
 		void* user_data,
+		void (*user_data_dealloc)(void*),
 		char* (*get_callback)(struct SortedArray*, void*),
 		void (*post_callback)(struct SortedArray*, void*, char*));
+
+// cleanup memory allocated from server
+void http_free(HTTP_Server* http_server);
 
 #endif

--- a/include/Routes.h
+++ b/include/Routes.h
@@ -10,11 +10,14 @@ struct SortedArray;
 struct Route {
 	char* key;
 	char* value;
+
 	void* user_data;
+	void (*user_data_dealloc)(void*);
 
 	char* (*get_callback)(
 			struct SortedArray * params, 
 			void* user_data);
+
 	void (*post_callback)(
 			struct SortedArray * params,
 			void* user_data,
@@ -27,6 +30,7 @@ struct Route * initRoute(
 		char* key, 
 		char* value,
 		void* user_data,
+		void (*user_data_dealloc)(void*),
 		char* (*get_callback)(struct SortedArray*, void*),
 		void (*post_callback)(struct SortedArray*, void*, char*));
 
@@ -35,6 +39,7 @@ void addRoute(
 		char* key, 
 		char* value,
 		void* user_data,
+		void (*user_data_dealloc)(void*),
 		char* (*get_callback)(struct SortedArray*, void*),
 		void (*post_callback)(struct SortedArray*, void*, char*));
 
@@ -43,5 +48,7 @@ struct Route * search(
 		char * key);
 
 void inorder(const struct Route * const root );
+
+void freeRoutes(struct Route ** root);
 
 #endif

--- a/include/SortedArray.h
+++ b/include/SortedArray.h
@@ -50,6 +50,6 @@ struct KeyValuePair * sarray_get(
 		struct SortedArray * sarray,
 		const char* key);
 
-void sarray_free(struct SortedArray * sarray);
+void sarray_free(struct SortedArray ** sarray);
 
 #endif

--- a/src/Routes.c
+++ b/src/Routes.c
@@ -7,6 +7,7 @@ struct Route * initRoute(
 		char* key, 
 		char* value,
 		void* user_data,
+		void (*user_data_dealloc)(void*),
 		char* (*get_callback)(struct SortedArray * sarray, void* user_data),
 		void (*post_callback)(struct SortedArray * sarray, void* user_data, char* request_body))
 {
@@ -17,6 +18,7 @@ struct Route * initRoute(
 	temp->get_callback = get_callback;
 	temp->post_callback = post_callback;
 	temp->user_data = user_data;
+	temp->user_data_dealloc = user_data_dealloc;
 
 	temp->left = temp->right = NULL;
 	return temp;
@@ -25,11 +27,30 @@ struct Route * initRoute(
 void inorder(const struct Route* const root)
 {
 
-    if (root != NULL) {
+    if (root != NULL)
+	{
         inorder(root->left);
         printf("%s -> %s \n", root->key, root->value);
         inorder(root->right);
     }
+}
+
+void freeRoutes(struct Route** root)
+{
+	if (*root != NULL)
+	{
+		if ((*root)->left)
+			freeRoutes(&(*root)->left);
+
+		if ((*root)->right)
+			freeRoutes(&(*root)->right);
+
+		if ((*root)->user_data_dealloc)
+			(*root)->user_data_dealloc((*root)->user_data);
+
+		free(*root);
+		*root = NULL;
+	}
 }
 
 void addRoute(
@@ -37,18 +58,19 @@ void addRoute(
 		char* key, 
 		char* value,
 		void* user_data,
+		void (*user_data_dealloc)(void* user_data),
 		char* (*get_callback)(struct SortedArray * params, void* user_data),
 		void (*post_callback)(struct SortedArray * params, void* user_data, char* request_body)) {
 	if (*root == NULL) {
-		*root = initRoute(key, value, user_data, get_callback, post_callback);
+		*root = initRoute(key, value, user_data, user_data_dealloc, get_callback, post_callback);
 	}
 	else if (strcmp(key, (*root)->key) == 0) {
 		printf("============ WARNING ============\n");
 		printf("A Route For \"%s\" Already Exists\n", key);
 	}else if (strcmp(key, (*root)->key) > 0) {
-		addRoute(&(*root)->right, key, value, user_data, get_callback, post_callback);
+		addRoute(&(*root)->right, key, value, user_data, user_data_dealloc, get_callback, post_callback);
 	}else {
-		addRoute(&(*root)->left, key, value, user_data, get_callback, post_callback);
+		addRoute(&(*root)->left, key, value, user_data, user_data_dealloc, get_callback, post_callback);
 	}
 }
 

--- a/src/SortedArray.c
+++ b/src/SortedArray.c
@@ -109,11 +109,11 @@ void sarray_clear(struct SortedArray * sarray)
 	sarray->n_members = 0;
 }
 
-void sarray_free(struct SortedArray * sarray)
+void sarray_free(struct SortedArray ** sarray)
 {
-	sarray_clear(sarray);
-	free(sarray->item);
-	sarray->item = NULL;
-	free(sarray);
-	sarray = NULL;
+	sarray_clear(*sarray);
+	free((*sarray)->item);
+	(*sarray)->item = NULL;
+	free(*sarray);
+	*sarray = NULL;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -34,6 +34,13 @@ void set_str(struct SortedArray * params, void* user_data, char* request_body)
 	*data = strdup(request_body);
 }
 
+void dealloc(void* user_data)
+{
+	char** data = user_data;
+	free(*data);
+	*data = NULL;
+}
+
 int main() {
 	// initiate HTTP_Server
 	HTTP_Server http_server;
@@ -47,9 +54,10 @@ int main() {
 	http_add_route_template(&http_server, "/sth", "sth.html");
 	http_add_route_template(&http_server, "/chicken", "chicken.html");
 
-	// TODO: might need to pass deallocators as well to free user data
+	// this route manages a string resource. We also pass a deallocator
+	// that the server can clean up when it's killed (e.g., Ctrl+C)
 	char* my_str = strdup("hello there!");
-	http_add_route_api(&http_server, "/mystr", &my_str, &get_str, &set_str);
+	http_add_route_api(&http_server, "/mystr", &my_str, &dealloc, &get_str, &set_str);
 
 	printf("\n====================================\n");
 	printf("=========ALL AVAILABLE ROUTES========\n");


### PR DESCRIPTION
We now have a way to clean up any dynamic memory from the user if they provide a custom deallocator for the user_data passed into a route. We also now have a server interrupt to cleanup all the memory when killing the process on abort signal (e.g., Ctrl+C)