### PR TITLE
(#14) moved all callback args to a struct

### DIFF
--- a/include/HTTP_Server.h
+++ b/include/HTTP_Server.h
@@ -10,6 +10,7 @@
 
 // forward declaration
 struct SortedArray;
+struct CallbackArgs;
 
 // note: please keep these in the same order as _status_code_text
 // as that's the corresponding lookup table
@@ -81,23 +82,9 @@ void http_add_route_api(
 		char* route_path,
 		void* user_data,
 		void (*user_data_dealloc)(void*),
-		char* (*get_callback)(
-			enum http_status_code_e*,
-			struct SortedArray*, 
-			struct SortedArray*, 
-			void*),
-		void (*post_callback)(
-			enum http_status_code_e*,
-			struct SortedArray*, 
-			struct SortedArray*, 
-			void*, 
-			char*),
-		void (*delete_callback)(
-			enum http_status_code_e*,
-			struct SortedArray*, 
-			struct SortedArray*, 
-			void*, 
-			char*));
+		char* (*get_callback)(struct CallbackArgs * const args),
+		void (*post_callback)(struct CallbackArgs * const args),
+		void (*delete_callback)(struct CallbackArgs * const args));
 
 // cleanup memory allocated from server
 void http_free(HTTP_Server* http_server);

--- a/include/Routes.h
+++ b/include/Routes.h
@@ -10,43 +10,40 @@
 // forward declaration
 struct SortedArray;
 
-struct Route {
+// arguments passed to GET/POST/DELETE/etc. callback functions
+// that end user can reference when handling API requests.
+struct CallbackArgs
+{
+	enum http_status_code_e* status_code;
+	const struct SortedArray * const params;
+	const struct SortedArray * const headers;
+	void* user_data;
+	const char* const request_body;
+};
+
+struct Route
+{
 	char* key;
 	char* value;
 
 	void* user_data;
 	void (*user_data_dealloc)(void*);
 
-	char* (*get_callback)(
-			enum http_status_code_e* status_code,
-			struct SortedArray * params, 
-			struct SortedArray * headers,
-			void* user_data);
-
-	void (*post_callback)(
-			enum http_status_code_e* status_code,
-			struct SortedArray * params,
-			struct SortedArray * headers,
-			void* user_data,
-			char* request_body);
-
-	void (*delete_callback)(
-			enum http_status_code_e* status_code,
-			struct SortedArray * params,
-			struct SortedArray * headers,
-			void* user_data,
-			char* request_body);
-
+	char* (*get_callback)(struct CallbackArgs * const args);
+	void (*post_callback)(struct CallbackArgs * const args);
+	void (*delete_callback)(struct CallbackArgs * const args);
+			
 	struct Route *left, *right;
 };
+
 struct Route * initRoute(
 		char* key, 
 		char* value,
 		void* user_data,
 		void (*user_data_dealloc)(void*),
-		char* (*get_callback)(enum http_status_code_e*, struct SortedArray*, struct SortedArray*, void*),
-		void (*post_callback)(enum http_status_code_e*, struct SortedArray*, struct SortedArray*, void*, char*),
-		void (*delete_callback)(enum http_status_code_e*, struct SortedArray*, struct SortedArray*, void*, char*));
+		char* (*get_callback)(struct CallbackArgs * const args),
+		void (*post_callback)(struct CallbackArgs * const args),
+		void (*delete_callback)(struct CallbackArgs * const args));
 
 void addRoute(
 		struct Route ** root, 
@@ -54,9 +51,9 @@ void addRoute(
 		char* value,
 		void* user_data,
 		void (*user_data_dealloc)(void*),
-		char* (*get_callback)(enum http_status_code_e*, struct SortedArray*, struct SortedArray*, void*),
-		void (*post_callback)(enum http_status_code_e*, struct SortedArray*, struct SortedArray*, void*, char*),
-		void (*delete_callback)(enum http_status_code_e*, struct SortedArray*, struct SortedArray*, void*, char*));
+		char* (*get_callback)(struct CallbackArgs * const args),
+		void (*post_callback)(struct CallbackArgs * const args),
+		void (*delete_callback)(struct CallbackArgs * const args));
 
 struct Route * search(
 		struct Route * root, 

--- a/src/Routes.c
+++ b/src/Routes.c
@@ -9,23 +9,9 @@ struct Route * initRoute(
 		char* value,
 		void* user_data,
 		void (*user_data_dealloc)(void*),
-		char* (*get_callback)(
-			enum http_status_code_e* status_code,
-			struct SortedArray * params, 
-			struct SortedArray * headers, 
-			void* user_data),
-		void (*post_callback)(
-			enum http_status_code_e* status_code,
-			struct SortedArray * params, 
-			struct SortedArray * headers,
-			void* user_data, 
-			char* request_body),
-		void (*delete_callback)(
-			enum http_status_code_e* status_code,
-			struct SortedArray * params,
-			struct SortedArray * headers,
-			void* user_data,
-			char* request_body))
+		char* (*get_callback)(struct CallbackArgs * const args),
+		void (*post_callback)(struct CallbackArgs * const args),
+		void (*delete_callback)(struct CallbackArgs * const args))
 {
 	struct Route * temp = (struct Route *) malloc(sizeof(struct Route));
 
@@ -78,23 +64,10 @@ void addRoute(
 		char* value,
 		void* user_data,
 		void (*user_data_dealloc)(void* user_data),
-		char* (*get_callback)(
-			enum http_status_code_e* status_code,
-			struct SortedArray * params, 
-			struct SortedArray * headers,
-			void* user_data),
-		void (*post_callback)(
-			enum http_status_code_e* status_code,
-			struct SortedArray * params, 
-			struct SortedArray * headers,
-			void* user_data, 
-			char* request_body),
-		void (*delete_callback)(
-			enum http_status_code_e* status_code,
-			struct SortedArray * params,
-			struct SortedArray * headers,
-			void* user_data,
-			char* request_body)) {
+		char* (*get_callback)(struct CallbackArgs * const args),
+		void (*post_callback)(struct CallbackArgs * const args),
+		void (*delete_callback)(struct CallbackArgs * const args))
+ {
 	if (*root == NULL) {
 		*root = initRoute(key, value, user_data, user_data_dealloc, get_callback, post_callback, delete_callback);
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -15,63 +15,37 @@
 #include "SortedArray.h"
 
 // each callback (GET/POST/DELETE) defaults to return 200 OK.
-// this can be changed by adjusting the pointer, e.g., *status_code = CREATED
+// this can be changed by adjusting the pointer, e.g., args->status_code = CREATED
 // see HTTP_Server.h for list of status codes
 
 // sample GET callback for /mystr (return the value of a local string)
-char* get_str(
-		enum http_status_code_e* status_code,
-		struct SortedArray * params, 
-		struct SortedArray * headers, 
-		void* user_data)
+char* get_str(struct CallbackArgs * const args)
 {
-	(void)status_code;
-	(void)params;
-	(void)headers;
-	return *(char**)user_data;
+	return *(char**)args->user_data;
 }
 
 // sample POST callback for /mystr (set the value of a local string)
-void set_str(
-		enum http_status_code_e* status_code,
-		struct SortedArray * params, 
-		struct SortedArray * headers, 
-		void* user_data, 
-		char* request_body)
+void set_str(struct CallbackArgs * const args)
 {
-	(void)status_code;
-	(void)params;
-	(void)headers;
-
 	// Our user_data is an address to a local char* variable.
 	// We cast to char** which holds the address and dereference + free before
 	// reallocating to the new string from the request_body
-	char** data = user_data;
+	char** data = args->user_data;
 	free(*data);
-	*data = strdup(request_body);
+	*data = strdup(args->request_body);
 
 	/* Example of how to pull a header value by key
 
-	struct KeyValuePair* find = sarray_get(headers, "MyHeader");
+	struct KeyValuePair* find = sarray_get(args->headers, "MyHeader");
 	*data = strdup(find->value);
 
 	*/
 }
 
 // sample DELETE callback for /mystr that just sets it to blank string
-void delete_str(
-		enum http_status_code_e* status_code,
-		struct SortedArray * params, 
-		struct SortedArray * headers, 
-		void* user_data, 
-		char* request_body)
+void delete_str(struct CallbackArgs * const args)
 {
-	(void)status_code;
-	(void)params;
-	(void)headers;
-	(void)request_body;
-
-	char** data = user_data;
+	char** data = args->user_data;
 	free(*data);
 	*data = strdup("");
 }


### PR DESCRIPTION
handling all the arguments in a struct is a lot more convenient than having to specify individual parameters all over the place